### PR TITLE
Add missing hf_present_line_window import

### DIFF
--- a/src/eqassoc/loaders.py
+++ b/src/eqassoc/loaders.py
@@ -8,7 +8,13 @@ from shapely.prepared import prep
 from sqlalchemy import create_engine
 from .config import PARAMS, PLANE_EPSG, PACIFIC_TZ
 from .regions import assign_region
-from .time_windows import localize_to_pacific, hf_stage_window, wd_window, prod_window
+from .time_windows import (
+    localize_to_pacific,
+    hf_stage_window,
+    hf_present_line_window,
+    wd_window,
+    prod_window,
+)
 
 DATAPATH = Path("/home/pgcseiscomp/Documents/bcer_data")
 


### PR DESCRIPTION
## Summary
- include `hf_present_line_window` in `loaders` imports so `load_hf_present_lines` can use it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bf55609c748333acc8ba8128f218ac