### PR TITLE
docs: improve README with CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,55 @@
 # eqassoc
 
-Resolution-aware earthquake–well association (stage vs present), CRS-safe, with incremental/full modes.
+Resolution-aware earthquake–well association (stage vs present) that can refresh in full or update incrementally while remaining CRS-safe.
 
-## Install (editable)
+## Installation
+
+Install the package in editable mode:
+
 ```bash
 pip install -e .
+```
 
-# full refresh
+## Command-line usage
+
+The project exposes a console script `eq-assoc`. Common invocations include:
+
+### Full database refresh
+
+Rebuild all associations from scratch, truncating existing result tables.
+
+```bash
 eq-assoc --mode full --assoc_mode detailed
+```
 
-## Usage
+### Incremental update
 
-# incremental update
+Process only earthquakes that have not been associated yet and append the results.
+
+```bash
 eq-assoc --mode incremental --assoc_mode detailed
+```
 
-# verbose, target quake and well
+### Verbose run targeting specific quake and well
+
+Output debug logs and force re-association for a single quake and well.
+
+```bash
 eq-assoc --mode incremental --assoc_mode detailed --verbose \
   --reassociate_quake 12345 --reassociate_wa 67890
+```
 
-Earthquakes are streamed from the database in batches (default 10k) so full
-re-runs do not exhaust memory.  The batch size can be adjusted with
-`--batch_size` if needed.
+### Batch size and in-memory mode
 
-Env:
+Earthquakes are streamed from the database in batches (default 10k) so full re-runs do not exhaust memory. Adjust the size and keep results in memory before writing:
 
-EQ_DB_URI (default: mysql+pymysql://root@localhost/earthquakes)
+```bash
+eq-assoc --mode incremental --batch_size 5000 --in_memory
+```
 
-data path in code defaults to /home/pgcseiscomp/Documents/bcer_data
+## Environment
+
+The CLI reads the database connection string from the `EQ_DB_URI` environment variable; the default is `mysql+pymysql://root@localhost/earthquakes`.
+
+Data files are expected under `/home/pgcseiscomp/Documents/bcer_data` unless configured otherwise.
+


### PR DESCRIPTION
## Summary
- expand README with installation instructions
- document common `eq-assoc` command-line invocations
- note required environment variables and defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bf5b3555848333925a0428ab589c35