### PR TITLE
Add setup configuration for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,9 @@ dependencies = [
 [project.scripts]
 eq-assoc = "eqassoc.cli:main"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = eqassoc
+version = 0.1.0
+description = Earthquake–well association (stage vs present), resolution-aware, CRS-safe
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = find:
+package_dir =
+    = src
+install_requires =
+    pandas>=2.0
+    numpy>=1.24
+    geopandas>=0.13
+    shapely>=2.0
+    scikit-learn>=1.2
+    SQLAlchemy>=2.0
+    pymysql>=1.0
+    pyproj>=3.5
+    joblib>=1.2
+python_requires = >=3.9
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    eq-assoc = eqassoc.cli:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- add setup.cfg and setup.py to enable editable installs with legacy tooling
- configure setuptools to find packages in the `src` layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -e . --no-deps` *(fails: Could not find a version that satisfies the requirement setuptools>=64)*

------
https://chatgpt.com/codex/tasks/task_b_68c04d4293508333979503c19e4d70ca