### PR TITLE
Allow selecting earthquake data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Earthquakes are streamed from the database in batches (default 10k) so full
 re-runs do not exhaust memory.  The batch size can be adjusted with
 `--batch_size` if needed.
 
+By default earthquakes are read from the `master_origin_3D` table. Use
+`--eq_source` to select among `master_origin`, `master_origin_3D`, or
+`hybrid_catalog`.
+
 Env:
 
 EQ_DB_URI (default: mysql+pymysql://root@localhost/earthquakes)

--- a/src/eqassoc/cli.py
+++ b/src/eqassoc/cli.py
@@ -3,7 +3,7 @@ import argparse, logging, os
 import pandas as pd
 from sqlalchemy import inspect, text
 
-from .config import DEFAULT_BATCH, DEFAULT_DB_URI
+from .config import DEFAULT_BATCH, DEFAULT_DB_URI, DEFAULT_EQ_TABLE
 from .loaders import (
     load_engine,
     iter_earthquakes,
@@ -31,6 +31,9 @@ def main():
     ap.add_argument("--n_jobs", type=int, default=1)  # kept for parity, not used
     ap.add_argument("--mode", choices=["incremental","full"], default="incremental")
     ap.add_argument("--batch_size", type=int, default=DEFAULT_BATCH)
+    ap.add_argument("--eq_source", choices=["master_origin", "master_origin_3D", "hybrid_catalog"],
+                    default=DEFAULT_EQ_TABLE,
+                    help="earthquake source table")
     ap.add_argument("--in_memory", action="store_true")
     ap.add_argument("--verbose", action="store_true", help="turn on DEBUG logging")
     ap.add_argument("--reassociate_quake", type=str, help="quake_id to force re-association for")
@@ -43,7 +46,7 @@ def main():
     eng = load_engine(db_uri)
 
     log.info("Loading source tables …")
-    eq_iter = iter_earthquakes("master_origin_3D", eng, args.batch_size)
+    eq_iter = iter_earthquakes(args.eq_source, eng, args.batch_size)
     tgt = load_target()
     hf_stage = load_hf_stage(tgt)
     hf_present = load_hf_present_lines()

--- a/src/eqassoc/config.py
+++ b/src/eqassoc/config.py
@@ -6,6 +6,7 @@ from shapely.geometry import LineString
 PLANE_EPSG = 26910
 DEFAULT_BATCH = 10_000
 DEFAULT_DB_URI = "mysql+pymysql://root@localhost/earthquakes"
+DEFAULT_EQ_TABLE = "master_origin_3D"
 PACIFIC_TZ = "Canada/Pacific"
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- add `--eq_source` flag to choose earthquake table (master_origin, master_origin_3D, hybrid_catalog)
- document available earthquake sources

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bf5b9a6da08333bc5272192309da71