### PR TITLE
Add example scripts for rerunning associations

### DIFF
--- a/examples/rerun_associations_generous.py
+++ b/examples/rerun_associations_generous.py
@@ -1,0 +1,98 @@
+"""Example: rerun associations with generous spatial/temporal criteria."""
+
+import pandas as pd
+import eqassoc.config as cfg
+import eqassoc.spatial as sp
+from eqassoc.regions import assign_region
+from eqassoc.process import process_batches
+from sample_data import load_raw_sample_data
+
+
+def main():
+    # Load raw sample datasets (non-production)
+    eq, hf_raw, wd_raw, prod_raw = load_raw_sample_data()
+
+    # Broad search radii and long time windows
+    cfg.update_params(
+        radius_km={
+            "HF": {"KSMMA": 20.0, "Northern Montney": 20.0},
+            "WD": {"KSMMA": 20.0, "Northern Montney": 20.0},
+            "PROD": {"KSMMA": 20.0, "Northern Montney": 20.0},
+        },
+        HF_Tmax_days=180,
+        WD_Tmax_days=365,
+        PROD_Tmax_days=365,
+    )
+    sp.PARAMS = cfg.PARAMS
+
+    # Build time windows manually using updated parameters
+    hf = hf_raw.copy()
+    hf["inj_start_local"] = hf["datetime"]
+    hf["decay_start_local"] = hf["datetime"]
+    hf["inj_end_local"] = hf["inj_start_local"] + pd.Timedelta(days=cfg.PARAMS.HF_Tmax_days)
+    hf = hf[[
+        "stage_id",
+        "well_id",
+        "pad_id",
+        "formation",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    hf = assign_region(hf)
+
+    wd = wd_raw.copy()
+    wd["inj_start_local"] = wd["yearmonth"].dt.to_period("M").dt.to_timestamp()
+    wd["decay_start_local"] = wd["inj_start_local"] + pd.DateOffset(months=cfg.PARAMS.WD_delay_months)
+    wd["inj_end_local"] = wd["inj_start_local"] + pd.Timedelta(days=cfg.PARAMS.WD_Tmax_days)
+    wd = wd[[
+        "well_id",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    wd = assign_region(wd)
+
+    prod = prod_raw.copy()
+    prod["pad_id"] = prod["well_id"]
+    prod["inj_start_local"] = prod["status_eff"]
+    prod["decay_start_local"] = prod["status_eff"]
+    prod["inj_end_local"] = prod["status_eff"] + pd.Timedelta(days=cfg.PARAMS.PROD_Tmax_days)
+    prod = prod[[
+        "well_id",
+        "pad_id",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    prod = assign_region(prod)
+
+    assoc, cls = process_batches(
+        eq_df=eq,
+        hf=hf,
+        wd=wd,
+        prod=prod,
+        lines_gdf=None,
+        mode="detailed",
+        batch=len(eq),
+        in_memory=True,
+        engine=None,
+    )
+
+    print("Generous association results")
+    print(assoc)
+    print()
+    print(cls)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rerun_associations_restrictive.py
+++ b/examples/rerun_associations_restrictive.py
@@ -1,0 +1,98 @@
+"""Example: rerun associations with restrictive spatial/temporal criteria."""
+
+import pandas as pd
+import eqassoc.config as cfg
+import eqassoc.spatial as sp
+from eqassoc.regions import assign_region
+from eqassoc.process import process_batches
+from sample_data import load_raw_sample_data
+
+
+def main():
+    # Load raw sample datasets (non-production)
+    eq, hf_raw, wd_raw, prod_raw = load_raw_sample_data()
+
+    # Tight search radii and short time windows
+    cfg.update_params(
+        radius_km={
+            "HF": {"KSMMA": 5.0, "Northern Montney": 5.0},
+            "WD": {"KSMMA": 5.0, "Northern Montney": 5.0},
+            "PROD": {"KSMMA": 5.0, "Northern Montney": 5.0},
+        },
+        HF_Tmax_days=30,
+        WD_Tmax_days=60,
+        PROD_Tmax_days=500,
+    )
+    sp.PARAMS = cfg.PARAMS
+
+    # Build time windows manually using updated parameters
+    hf = hf_raw.copy()
+    hf["inj_start_local"] = hf["datetime"]
+    hf["decay_start_local"] = hf["datetime"]
+    hf["inj_end_local"] = hf["inj_start_local"] + pd.Timedelta(days=cfg.PARAMS.HF_Tmax_days)
+    hf = hf[[
+        "stage_id",
+        "well_id",
+        "pad_id",
+        "formation",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    hf = assign_region(hf)
+
+    wd = wd_raw.copy()
+    wd["inj_start_local"] = wd["yearmonth"].dt.to_period("M").dt.to_timestamp()
+    wd["decay_start_local"] = wd["inj_start_local"] + pd.DateOffset(months=cfg.PARAMS.WD_delay_months)
+    wd["inj_end_local"] = wd["inj_start_local"] + pd.Timedelta(days=cfg.PARAMS.WD_Tmax_days)
+    wd = wd[[
+        "well_id",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    wd = assign_region(wd)
+
+    prod = prod_raw.copy()
+    prod["pad_id"] = prod["well_id"]
+    prod["inj_start_local"] = prod["status_eff"]
+    prod["decay_start_local"] = prod["status_eff"]
+    prod["inj_end_local"] = prod["status_eff"] + pd.Timedelta(days=cfg.PARAMS.PROD_Tmax_days)
+    prod = prod[[
+        "well_id",
+        "pad_id",
+        "latitude",
+        "longitude",
+        "depth_km",
+        "inj_start_local",
+        "decay_start_local",
+        "inj_end_local",
+    ]]
+    prod = assign_region(prod)
+
+    assoc, cls = process_batches(
+        eq_df=eq,
+        hf=hf,
+        wd=wd,
+        prod=prod,
+        lines_gdf=None,
+        mode="detailed",
+        batch=len(eq),
+        in_memory=True,
+        engine=None,
+    )
+
+    print("Restrictive association results")
+    print(assoc)
+    print()
+    print(cls)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sample_data.py
+++ b/examples/sample_data.py
@@ -1,0 +1,58 @@
+import pandas as pd
+from eqassoc.regions import assign_region
+
+
+def load_raw_sample_data():
+    """Return small in-memory DataFrames for earthquakes and activities."""
+    # Earthquake catalog with times already localized to Pacific
+    eq = pd.DataFrame(
+        {
+            "quake_id": [1, 2],
+            "latitude": [56.10, 56.30],
+            "longitude": [-121.30, -121.20],
+            "depth_km": [3.0, 5.0],
+            "time_local": pd.to_datetime(["2023-02-15", "2023-02-20"]),
+        }
+    )
+    eq = assign_region(eq)
+
+    # Raw HF stage record
+    hf = pd.DataFrame(
+        {
+            "stage_id": [10],
+            "well_id": ["A1"],
+            "pad_id": ["P1"],
+            "formation": ["Lower Middle Montney"],
+            "latitude": [56.11],
+            "longitude": [-121.31],
+            "depth_m": [2500],
+            "datetime": pd.to_datetime(["2023-01-01"]),
+            "date": [pd.Timestamp("2023-01-01").date()],
+        }
+    )
+    hf["depth_km"] = hf["depth_m"] / 1000.0
+
+    # Raw water disposal record (monthly)
+    wd = pd.DataFrame(
+        {
+            "well_id": ["W1"],
+            "latitude": [56.09],
+            "longitude": [-121.29],
+            "depth_m": [1500],
+            "yearmonth": pd.to_datetime(["2022-12-01"]),
+        }
+    )
+    wd["depth_km"] = wd["depth_m"] / 1000.0
+
+    # Raw production record
+    prod = pd.DataFrame(
+        {
+            "well_id": ["P2"],
+            "latitude": [56.12],
+            "longitude": [-121.32],
+            "status_eff": pd.to_datetime(["2022-01-01"]),
+        }
+    )
+    prod["depth_km"] = 2.0
+
+    return eq, hf, wd, prod


### PR DESCRIPTION
## Summary
- add small in-memory sample dataset for earthquakes and well activities
- add restrictive and generous association scripts that avoid production data

## Testing
- `PYTHONPATH=src:examples python examples/rerun_associations_restrictive.py`
- `PYTHONPATH=src:examples python examples/rerun_associations_generous.py`


------
https://chatgpt.com/codex/tasks/task_b_68c066fe3e9883338f9795d00699da22