### PR TITLE
Convert earthquake timestamps to Fort St. John time

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ The CLI reads the database connection string from the `EQ_DB_URI` environment va
 
 Data files are expected under `/home/pgcseiscomp/Documents/bcer_data` unless configured otherwise.
 
+## Time zones
+
+Earthquake timestamps are stored in UTC, whereas well activity data
+uses Fort St. John local time (America/Fort_Nelson).  All earthquake
+times are converted to Fort St. John time during loading so that both
+datasets share the same time reference.
+

--- a/src/eqassoc/config.py
+++ b/src/eqassoc/config.py
@@ -6,7 +6,9 @@ from shapely.geometry import LineString
 PLANE_EPSG = 26910
 DEFAULT_BATCH = 10_000
 DEFAULT_DB_URI = "mysql+pymysql://root@localhost/earthquakes"
-PACIFIC_TZ = "Canada/Pacific"
+# Fort St. John operates on Mountain Time without daylight savings.
+# Use the corresponding zoneinfo key for conversions.
+FORT_ST_JOHN_TZ = "America/Fort_Nelson"
 
 @dataclass(frozen=True)
 class Params:

--- a/src/eqassoc/loaders.py
+++ b/src/eqassoc/loaders.py
@@ -6,10 +6,10 @@ from shapely.geometry import LineString
 from shapely.prepared import prep
 
 from sqlalchemy import create_engine
-from .config import PARAMS, PLANE_EPSG, PACIFIC_TZ
+from .config import PARAMS, PLANE_EPSG
 from .regions import assign_region
 from .time_windows import (
-    localize_to_pacific,
+    utc_to_fort_st_john,
     hf_stage_window,
     hf_present_line_window,
     wd_window,
@@ -31,7 +31,8 @@ def load_earthquakes(tbl: str, eng):
             "depth": "depth_km",
         }
     )
-    df["time_local"] = localize_to_pacific(df["datetime"])
+    # Convert earthquake timestamps (UTC) to Fort St. John time to match well data
+    df["time_local"] = utc_to_fort_st_john(df["datetime"])
     df = df.dropna(subset=["latitude", "longitude", "time_local"]).reset_index(drop=True)
     return df[["quake_id", "latitude", "longitude", "depth_km", "time_local"]]
 
@@ -52,7 +53,8 @@ def iter_earthquakes(tbl: str, eng, batch: int):
                 "depth": "depth_km",
             }
         )
-        chunk["time_local"] = localize_to_pacific(chunk["datetime"])
+        # Convert earthquake timestamps (UTC) to Fort St. John time
+        chunk["time_local"] = utc_to_fort_st_john(chunk["datetime"])
         chunk = chunk.dropna(subset=["latitude", "longitude", "time_local"]).reset_index(drop=True)
         yield chunk[["quake_id", "latitude", "longitude", "depth_km", "time_local"]]
 

--- a/src/eqassoc/time_windows.py
+++ b/src/eqassoc/time_windows.py
@@ -3,12 +3,15 @@ import math
 import numpy as np
 import pandas as pd
 from pandas import DateOffset
-from .config import PARAMS, PACIFIC_TZ
+from .config import PARAMS, FORT_ST_JOHN_TZ
 
-def localize_to_pacific(ts: pd.Series) -> pd.Series:
-    return (pd.to_datetime(ts, utc=True)
-              .dt.tz_convert(PACIFIC_TZ)
-              .dt.tz_localize(None))
+def utc_to_fort_st_john(ts: pd.Series) -> pd.Series:
+    """Convert UTC timestamps to Fort St. John local time."""
+    return (
+        pd.to_datetime(ts, utc=True)
+          .dt.tz_convert(FORT_ST_JOHN_TZ)
+          .dt.tz_localize(None)
+    )
 
 def exp_decay(dt_days: np.ndarray, tau_days: float) -> np.ndarray:
     """Vectorized exp decay; dt_days >= 0. Uses e^(-dt/tau)."""


### PR DESCRIPTION
## Summary
- Convert UTC earthquake times to Fort St. John local time using `America/Fort_Nelson`
- Add helper `utc_to_fort_st_john` and document timezone handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c068d40f98833394f6307f7cb824fa